### PR TITLE
chore: add CODEOWNERS for required review enforcement

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Synctx — Code Owners
+# All changes require approval from the maintainer.
+
+* @adsathye


### PR DESCRIPTION
Adds a CODEOWNERS file so all changes require approval from @adsathye.

Branch protection is already configured with:
- Required status checks (all 5 CI jobs must pass)
- Require CODEOWNERS review enabled
- Enforce on admins enabled
- Dismiss stale reviews on new commits
- No force push / branch deletion